### PR TITLE
Feature/alternative import scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,141 @@ cp .env.example .env
 npm run build
 npm run preview
 ```
+
+---
+
+## Using External State Context for Script Injection
+
+KILN supports advanced customization by allowing you to inject external scripts that can read, write, and react to form field values at runtime. This enables powerful automation, custom validation, and integration with external systems—without modifying the core React code. This integration allows for you to modify the state of the form fields within the React context.
+
+### How It Works
+
+- The form system exposes a global `window.externalFormStore` object.
+- When all fields are registered, the system calls a global `window.externalFormInit(refsMap)` function (if present), passing a map of field IDs to field reference objects.
+
+### Writing an External Script
+
+**1. Define your logic in a function called `externalFormInit`:**
+
+This function receives a `refsMap` of all registered fields. You can use `window.externalFormStore` for advanced operations.
+
+**2. Use the field API:**
+
+Each field reference in `refsMap` (or via `store.getFieldRef(fieldId)`) exposes:
+
+- `getValue()`: Get the current value of the field.
+- `setValue(value)`: Set the value of the field.
+
+**3. Subscribe to field changes:**
+
+### Example Script
+
+```js
+/**
+ * Create the main initialization function that will be called by the external form system
+ * @param {Object} refsMap - Map of field IDs to field reference objects
+ */
+function externalFormInit(refsMap) {
+  const store = window.externalFormStore;
+
+  // Concatenate text from inputs with class
+  // and set it to the target field with ID
+  concatenateText({
+    source_class: "className",
+    target_id: "elementId",
+  });
+
+  // Get source and update target field state
+  conditionalDropdownToInput({
+    source_id: "elementId",
+    target_id: "ElementId",
+    optionMap: {
+      "british-columbia": "BC",
+      alberta: "AB",
+    },
+  });
+
+  console.log("Form scripts initialized successfully.");
+}
+
+// Create helper functions that can be reused in the script
+
+/**
+ * Links a dropdown field to an input field using the external form store.
+ * @param {Object} params
+ * @param {string} params.source_id - fieldId for dropdown
+ * @param {string} params.target_id - fieldId for input
+ * @param {Object} params.optionMap - mapping of dropdown values to input values
+ */
+function conditionalDropdownToInput({ source_id, target_id, optionMap }) {
+  const store = window.externalFormStore;
+  let src = store.getFieldRef(source_id);
+  let tgt = store.getFieldRef(target_id);
+  const update = (value) => {
+    const mapped = optionMap[value] || "";
+    if (tgt.getValue() !== mapped) {
+      tgt.setValue(mapped);
+    }
+  };
+  const unsubscribe = store.subscribeToField(source_id, update);
+  const initialValue = src.getValue();
+  if (initialValue) {
+    update(initialValue);
+  }
+  return unsubscribe;
+}
+
+/**
+ * Concatenates the values of all input fields with a given class and sets the result to a target field.
+ * Mixes query selector with the external form store.
+ * @param {Object} params
+ * @param {string} params.source_class - class name of source input fields
+ * @param {string} params.target_id - fieldId for the target field
+ */
+function concatenateText({ source_class, target_id }) {
+  const store = window.externalFormStore;
+  const tgtField = store.getFieldRef(target_id);
+  const className = source_class.startsWith(".")
+    ? source_class.slice(1)
+    : source_class;
+  const selector = `.${CSS.escape(className)} input`;
+  const inputs = Array.from(document.querySelectorAll(selector));
+  if (inputs.length === 0) return;
+
+  const update = () => {
+    const concatenated = inputs.map((i) => i.value || "").join("");
+    if (tgtField.getValue() !== concatenated) {
+      tgtField.setValue(concatenated);
+    }
+  };
+
+  // Listen to each input's changes
+  const listeners = inputs.map((input) => {
+    const handler = () => update();
+    input.addEventListener("input", handler);
+    return { input, handler };
+  });
+  update();
+
+  return () => {
+    listeners.forEach(({ input, handler }) =>
+      input.removeEventListener("input", handler)
+    );
+  };
+}
+
+// Make the function available globally for the external form system
+window.externalFormInit = externalFormInit;
+
+// Dispatch event to let the system know the script is ready
+window.dispatchEvent(new CustomEvent("externalScriptReady"));
+```
+
+### Tips
+
+- **Field IDs:** Use the field IDs from your form definition.
+- **Debugging:** Use `console.log` to inspect `refsMap` and field values.
+- **Cleanup:** Return unsubscribe functions if you need to remove listeners on script reload.
+- **Advanced:** You can also use `store.subscribe` to listen to all state changes, or manipulate group fields using the metadata.
+
+---

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { Routes, Route, useLocation, Navigate } from "react-router-dom";
 
 import { initializeKeycloak } from "./keycloak";
 import { PrivateRoute } from "./PrivateRoute";
+import { ExternalStateProvider } from './ExternalStateContext';
 
 export const AuthenticationContext = createContext<any>(null);
 
@@ -62,32 +63,34 @@ const App: React.FC = () => {
 
   return (
     <AuthenticationContext.Provider value={keycloak}>
-      <Routes>
-        {/* Root route - redirect to preview in standalone mode, otherwise to new */}
-        <Route path="/" element={<Navigate to={isStandaloneMode ? "/preview" : "/new"} replace />} />
-        
-        {/* Public Routes */}
-        <Route path="/preview" element={<PreviewFormPage />} />
-        <Route path="/preview/:id" element={<ExternalPreviewPage />} />
-        <Route path="/printToPDF" element={<PrintFormPage />} />
-        <Route path="/unauthorized" element={<UnauthorizedPage />} />
-        <Route path="/error" element={<ErrorPage />} />
+      <ExternalStateProvider>
+        <Routes>
+          {/* Root route - redirect to preview in standalone mode, otherwise to new */}
+          <Route path="/" element={<Navigate to={isStandaloneMode ? "/preview" : "/new"} replace />} />
+          
+          {/* Public Routes */}
+          <Route path="/preview" element={<PreviewFormPage />} />
+          <Route path="/preview/:id" element={<ExternalPreviewPage />} />
+          <Route path="/printToPDF" element={<PrintFormPage />} />
+          <Route path="/unauthorized" element={<UnauthorizedPage />} />
+          <Route path="/error" element={<ErrorPage />} />
 
-        {/* Protected Routes - bypass PrivateRoute in standalone mode */}
-        {isStandaloneMode ? (
-          <>
-            <Route path="/new" element={<NewFormPage />} />
-            <Route path="/edit" element={<EditFormPage />} />
-            <Route path="/view" element={<ViewFormPage />} />
-          </>
-        ) : (
-          <>
-            <Route path="/new" element={<PrivateRoute><NewFormPage /></PrivateRoute>} />
-            <Route path="/edit" element={<PrivateRoute><EditFormPage /></PrivateRoute>} />
-            <Route path="/view" element={<PrivateRoute><ViewFormPage /></PrivateRoute>} />
-          </>
-        )}
-      </Routes>
+          {/* Protected Routes - bypass PrivateRoute in standalone mode */}
+          {isStandaloneMode ? (
+            <>
+              <Route path="/new" element={<NewFormPage />} />
+              <Route path="/edit" element={<EditFormPage />} />
+              <Route path="/view" element={<ViewFormPage />} />
+            </>
+          ) : (
+            <>
+              <Route path="/new" element={<PrivateRoute><NewFormPage /></PrivateRoute>} />
+              <Route path="/edit" element={<PrivateRoute><EditFormPage /></PrivateRoute>} />
+              <Route path="/view" element={<PrivateRoute><ViewFormPage /></PrivateRoute>} />
+            </>
+          )}
+        </Routes>
+      </ExternalStateProvider>
     </AuthenticationContext.Provider>
   );
 };

--- a/src/ExternalStateContext.tsx
+++ b/src/ExternalStateContext.tsx
@@ -1,0 +1,365 @@
+// ExternalStateContext.js
+import React, { createContext, useContext, useState, useEffect } from "react";
+
+interface FieldMethods {
+  setValue: (value: any) => void;
+  getValue: () => any;
+  validate: (value?: any) => string | null;
+  setError: (error: string | null) => void;
+  getError: () => string | null;
+  fieldType: string;
+  isGroupField: boolean;
+  groupId: string | null;
+  groupIndex: number | null;
+}
+
+interface ExternalFormStore {
+  state: { [key: string]: any };
+  listeners: Set<(state: any) => void>;
+  fieldRefs: Map<string, FieldMethods>;
+  setState: (fieldId: string, value: any) => void;
+  getState: (fieldId: string) => any;
+  subscribe: (listener: (state: any) => void) => () => void;
+  subscribeToField: (
+    fieldId: string,
+    listener: (value: any, fieldId: string) => void
+  ) => () => void;
+  notifyListeners: () => void;
+  registerField: (fieldId: string, methods: FieldMethods) => void;
+  getFieldRef: (fieldId: string) => FieldMethods | undefined;
+  getAllFieldRefs: () => { [key: string]: FieldMethods };
+  initializeExternalScript: () => void;
+  reinitializeExternalScript: () => void;
+  getRegistrationStatus: () => {
+    totalFields: number;
+    registeredFields: string[];
+  };
+  clearRegistrations: () => void;
+}
+
+// External store that lives outside React
+class ExternalFormStoreImpl implements ExternalFormStore {
+  state: { [key: string]: any } = {};
+  listeners = new Set<(state: any) => void>();
+  fieldRefs = new Map<string, FieldMethods>();
+  private externalScriptInitialized = false;
+  private isUpdating = false; // Add flag to prevent recursion
+  private registrationCompleteTimeout: NodeJS.Timeout | null = null;
+  private fieldListeners = new Map<
+    string,
+    Set<(value: any, fieldId: string) => void>
+  >();
+
+  setState(fieldId: string, value: any) {
+    // Prevent recursion by checking if we're already updating
+    if (this.isUpdating) {
+      return;
+    }
+
+    const oldValue = this.state[fieldId];
+    this.state[fieldId] = value;
+
+    // Only notify if value actually changed
+    if (oldValue !== value) {
+      this.notifyListeners();
+      this.notifyFieldListeners(fieldId, value);
+    }
+  }
+
+  getState(fieldId: string) {
+    return this.state[fieldId];
+  }
+
+  subscribe(listener: (state: any) => void) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  subscribeToField(
+    fieldId: string,
+    listener: (value: any, fieldId: string) => void
+  ) {
+    if (!this.fieldListeners.has(fieldId)) {
+      this.fieldListeners.set(fieldId, new Set());
+    }
+    this.fieldListeners.get(fieldId)!.add(listener);
+
+    return () => {
+      const listeners = this.fieldListeners.get(fieldId);
+      if (listeners) {
+        listeners.delete(listener);
+        if (listeners.size === 0) {
+          this.fieldListeners.delete(fieldId);
+        }
+      }
+    };
+  }
+
+  notifyListeners() {
+    // Prevent recursion during listener notifications
+    if (this.isUpdating) {
+      return;
+    }
+
+    this.isUpdating = true;
+    try {
+      this.listeners.forEach((listener) => {
+        try {
+          listener(this.state);
+        } catch (error) {
+          console.error("Error in store listener:", error);
+        }
+      });
+    } finally {
+      this.isUpdating = false;
+    }
+  }
+
+  private notifyFieldListeners(fieldId: string, value: any) {
+    const listeners = this.fieldListeners.get(fieldId);
+    if (listeners) {
+      listeners.forEach((listener) => {
+        try {
+          listener(value, fieldId);
+        } catch (error) {
+          console.error(`Error in field listener for ${fieldId}:`, error);
+        }
+      });
+    }
+  }
+
+  registerField(fieldId: string, methods: FieldMethods) {
+    this.fieldRefs.set(fieldId, methods);
+
+    // Initialize state with current value without triggering listeners
+    const currentValue = methods.getValue();
+    if (currentValue !== undefined && currentValue !== "") {
+      this.state[fieldId] = currentValue;
+    }
+
+    // Clear previous timeout and set a new one
+    if (this.registrationCompleteTimeout) {
+      clearTimeout(this.registrationCompleteTimeout);
+    }
+
+    // Wait for field registrations to complete, then initialize external script
+    this.registrationCompleteTimeout = setTimeout(() => {
+      console.log(
+        "Field registration appears complete, initializing external script"
+      );
+      this.reinitializeExternalScript();
+    }, 500); // Wait 500ms after last field registration
+  }
+
+  getFieldRef(fieldId: string) {
+    return this.fieldRefs.get(fieldId);
+  }
+
+  getAllFieldRefs() {
+    const refs: { [key: string]: FieldMethods } = {};
+    this.fieldRefs.forEach((methods, fieldId) => {
+      refs[fieldId] = methods;
+    });
+    return refs;
+  }
+
+  getRegistrationStatus() {
+    return {
+      totalFields: this.fieldRefs.size,
+      registeredFields: Array.from(this.fieldRefs.keys()),
+    };
+  }
+
+  clearRegistrations() {
+    console.log("Clearing all field registrations");
+    if (this.registrationCompleteTimeout) {
+      clearTimeout(this.registrationCompleteTimeout);
+      this.registrationCompleteTimeout = null;
+    }
+    this.fieldRefs.clear();
+    this.fieldListeners.clear();
+    this.state = {};
+    this.externalScriptInitialized = false;
+  }
+
+  reinitializeExternalScript() {
+    console.log("Re-initializing external script");
+    this.externalScriptInitialized = false;
+    this.initializeExternalScript();
+  }
+
+  initializeExternalScript() {
+    if (
+      window.externalFormInit &&
+      typeof window.externalFormInit === "function" &&
+      !this.externalScriptInitialized
+    ) {
+      try {
+        const status = this.getRegistrationStatus();
+        console.log("Initializing external script with field refs:", status);
+
+        // Don't initialize if no fields are registered yet
+        if (status.totalFields === 0) {
+          console.log("No fields registered yet, skipping initialization");
+          return;
+        }
+
+        // Sync all field values to the store before creating refs
+        this.fieldRefs.forEach((methods, fieldId) => {
+          const currentValue = methods.getValue();
+          if (currentValue !== undefined && currentValue !== "") {
+            this.state[fieldId] = currentValue;
+          }
+        });
+
+        // Create stable ref objects for external script
+        const refsForExternalScript: { [key: string]: any } = {};
+        this.fieldRefs.forEach((methods, fieldId) => {
+          refsForExternalScript[fieldId] = {
+            current: null, // DOM element will be set by components
+            setValue: (value: any) => {
+              // Prevent recursion by using a flag
+              if (this.isUpdating) {
+                return;
+              }
+
+              // Update the store state first
+              this.state[fieldId] = value;
+
+              // Then update the component
+              methods.setValue(value);
+
+              // Notify listeners after both updates
+              this.notifyListeners();
+              this.notifyFieldListeners(fieldId, value);
+            },
+            getValue: () => {
+              // Get the most current value from the component
+              const componentValue = methods.getValue();
+
+              // If component has a value, sync it to store and return it
+              if (componentValue !== undefined && componentValue !== "") {
+                if (this.state[fieldId] !== componentValue) {
+                  this.state[fieldId] = componentValue;
+                }
+                return componentValue;
+              }
+
+              // If component is empty, check store
+              const storeValue = this.state[fieldId];
+              if (storeValue !== undefined && storeValue !== "") {
+                return storeValue;
+              }
+
+              // Return empty string as default
+              return "";
+            },
+            validate: methods.validate,
+            setError: methods.setError,
+            getError: methods.getError,
+            fieldType: methods.fieldType,
+            isGroupField: methods.isGroupField,
+            groupId: methods.groupId,
+            groupIndex: methods.groupIndex,
+          };
+        });
+
+        // Add the field-specific subscription method to the store reference
+        refsForExternalScript._store = {
+          subscribeToField: this.subscribeToField.bind(this),
+          subscribe: this.subscribe.bind(this),
+          getState: this.getState.bind(this),
+          setState: this.setState.bind(this),
+        };
+
+        window.externalFormInit(refsForExternalScript);
+        this.externalScriptInitialized = true;
+        console.log("External script initialized successfully");
+      } catch (error) {
+        console.error("Error initializing external script:", error);
+      }
+    } else if (!window.externalFormInit) {
+      console.log("External script not available yet, will retry...");
+    } else if (this.externalScriptInitialized) {
+      console.log("External script already initialized");
+    }
+  }
+
+  resetExternalScript() {
+    console.log("Resetting external script initialization flag");
+    this.externalScriptInitialized = false;
+  }
+}
+
+// Global store instance
+declare global {
+  interface Window {
+    externalFormStore: ExternalFormStore;
+    externalFormInit?: (refsMap: { [key: string]: any }) => void;
+  }
+}
+
+if (!window.externalFormStore) {
+  window.externalFormStore = new ExternalFormStoreImpl();
+}
+
+interface ExternalStateContextType {
+  state: { [key: string]: any };
+  store: ExternalFormStore;
+}
+
+const ExternalStateContext = createContext<
+  ExternalStateContextType | undefined
+>(undefined);
+
+export const ExternalStateProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [state, setState] = useState(window.externalFormStore.state);
+
+  useEffect(() => {
+    const unsubscribe = window.externalFormStore.subscribe(setState);
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    // Listen for external script ready event
+    const handleExternalScriptReady = () => {
+      console.log("External script ready event received");
+      // Don't initialize immediately, let field registration complete first
+      setTimeout(() => {
+        window.externalFormStore.reinitializeExternalScript();
+      }, 1000);
+    };
+
+    window.addEventListener("externalScriptReady", handleExternalScriptReady);
+
+    return () => {
+      window.removeEventListener(
+        "externalScriptReady",
+        handleExternalScriptReady
+      );
+    };
+  }, []);
+
+  return (
+    <ExternalStateContext.Provider
+      value={{
+        state,
+        store: window.externalFormStore,
+      }}
+    >
+      {children}
+    </ExternalStateContext.Provider>
+  );
+};
+
+export const useExternalState = () => {
+  const context = useContext(ExternalStateContext);
+  if (!context) {
+    throw new Error(
+      "useExternalState must be used within an ExternalStateProvider"
+    );
+  }
+  return context;
+};

--- a/src/ExternalStateContext.tsx
+++ b/src/ExternalStateContext.tsx
@@ -1,3 +1,15 @@
+/**
+ * ExternalStateContext provides a global store for form field values and methods.
+ *
+ * External scripts can interact with the form via:
+ *   - window.externalFormStore: The global store instance.
+ *   - window.externalFormInit(refsMap): Called when all fields are registered.
+ *
+ * Each field reference (from store.getFieldRef(fieldId) or refsMap[fieldId]) exposes:
+ *   - setValue(value): Set the field value.
+ *   - getValue(): Get the current field value.
+ *
+ */
 import React, { createContext, useState, useEffect } from "react";
 
 interface FieldMethods {

--- a/src/ExternalStateContext.tsx
+++ b/src/ExternalStateContext.tsx
@@ -1,5 +1,4 @@
-// ExternalStateContext.js
-import React, { createContext, useContext, useState, useEffect } from "react";
+import React, { createContext, useState, useEffect } from "react";
 
 interface FieldMethods {
   setValue: (value: any) => void;
@@ -196,11 +195,10 @@ class ExternalFormStoreImpl implements ExternalFormStore {
     ) {
       try {
         const status = this.getRegistrationStatus();
-        console.log("Initializing external script with field refs:", status);
 
-        // Don't initialize if no fields are registered yet
+        // Don't initialize if no fields are registered
         if (status.totalFields === 0) {
-          console.log("No fields registered yet, skipping initialization");
+          console.log("No fields registered, skipping initialization");
           return;
         }
 
@@ -216,9 +214,8 @@ class ExternalFormStoreImpl implements ExternalFormStore {
         const refsForExternalScript: { [key: string]: any } = {};
         this.fieldRefs.forEach((methods, fieldId) => {
           refsForExternalScript[fieldId] = {
-            current: null, // DOM element will be set by components
+            current: null,
             setValue: (value: any) => {
-              // Prevent recursion by using a flag
               if (this.isUpdating) {
                 return;
               }
@@ -308,7 +305,7 @@ interface ExternalStateContextType {
   store: ExternalFormStore;
 }
 
-const ExternalStateContext = createContext<
+export const ExternalStateContext = createContext<
   ExternalStateContextType | undefined
 >(undefined);
 
@@ -326,7 +323,6 @@ export const ExternalStateProvider: React.FC<{ children: React.ReactNode }> = ({
     // Listen for external script ready event
     const handleExternalScriptReady = () => {
       console.log("External script ready event received");
-      // Don't initialize immediately, let field registration complete first
       setTimeout(() => {
         window.externalFormStore.reinitializeExternalScript();
       }, 1000);
@@ -352,14 +348,4 @@ export const ExternalStateProvider: React.FC<{ children: React.ReactNode }> = ({
       {children}
     </ExternalStateContext.Provider>
   );
-};
-
-export const useExternalState = () => {
-  const context = useContext(ExternalStateContext);
-  if (!context) {
-    throw new Error(
-      "useExternalState must be used within an ExternalStateProvider"
-    );
-  }
-  return context;
 };

--- a/src/hooks/ExternalStateHook.tsx
+++ b/src/hooks/ExternalStateHook.tsx
@@ -1,0 +1,17 @@
+import { useContext } from "react";
+import { ExternalStateContext } from "../ExternalStateContext";
+
+interface ExternalStateContextType {
+  state: { [key: string]: any };
+  store: any;
+}
+
+export const useExternalState = (): ExternalStateContextType => {
+  const context = useContext(ExternalStateContext);
+  if (!context) {
+    throw new Error(
+      "useExternalState must be used within an ExternalStateProvider"
+    );
+  }
+  return context;
+};

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,0 +1,214 @@
+/*
+ * Provide context for field registration and management
+ * This file contains functions to create and manage field registrations
+ * in the external state store.
+ * It includes methods for setting and getting field values, errors, and validation.
+ * This enables the external injection of state management for form fields.
+ */
+
+// Create field registration
+export function createFieldRegistration({
+  fieldId,
+  groupId,
+  groupIndex,
+  store,
+  formData,
+  groupStates,
+  formStates,
+  setFormErrors,
+  handleInputChange,
+  validateField,
+}: {
+  fieldId: string;
+  groupId?: string;
+  groupIndex?: number;
+  store: any;
+  formData: any;
+  groupStates: { [key: string]: any[] };
+  formStates: { [key: string]: any };
+  setFormErrors: (fn: (prev: any) => any) => void;
+  handleInputChange: (
+    fieldId: string,
+    value: any,
+    groupId: string | null,
+    groupIndex: number | null,
+    field: any
+  ) => void;
+  validateField: (field: any, value: any) => string | null;
+}) {
+  const existingRegistration = store.getFieldRef(fieldId);
+  if (existingRegistration) {
+    return existingRegistration;
+  }
+
+  const field = findFieldById(fieldId, formData);
+  const fieldInfo = parseFieldId(fieldId, groupStates);
+
+  const methods = {
+    setValue: (value: any) => {
+      const currentValue =
+        groupId !== undefined && groupIndex !== undefined
+          ? groupStates[groupId]?.[groupIndex]?.[fieldId]
+          : formStates[fieldId];
+
+      if (currentValue === value) {
+        return;
+      }
+
+      handleInputChange(
+        fieldId,
+        value,
+        groupId || null,
+        groupIndex || null,
+        field || {}
+      );
+    },
+
+    getValue: () => {
+      let value;
+      if (groupId !== undefined && groupIndex !== undefined) {
+        value = groupStates[groupId]?.[groupIndex]?.[fieldId];
+      } else if (
+        fieldInfo.isGroupField &&
+        fieldInfo.groupId &&
+        fieldInfo.groupIndex !== null
+      ) {
+        value =
+          groupStates[fieldInfo.groupId]?.[fieldInfo.groupIndex]?.[fieldId];
+      } else {
+        value = formStates[fieldId];
+      }
+      return value || "";
+    },
+
+    setError: (error: string | null) => {
+      setFormErrors((prev: any) => ({ ...prev, [fieldId]: error }));
+    },
+
+    getError: () => formStates[fieldId],
+
+    validate: (value?: any) => {
+      if (field) {
+        const valueToValidate =
+          value !== undefined
+            ? value
+            : groupId !== undefined && groupIndex !== undefined
+            ? groupStates[groupId]?.[groupIndex]?.[fieldId]
+            : formStates[fieldId];
+        return validateField(field, valueToValidate);
+      }
+      return null;
+    },
+
+    fieldType: field?.type || "unknown",
+    isGroupField: fieldInfo.isGroupField,
+    groupId: fieldInfo.groupId,
+    groupIndex: fieldInfo.groupIndex,
+  };
+
+  store.registerField(fieldId, methods);
+  return methods;
+}
+
+// Register all fields
+export function registerAllFields({
+  items,
+  parentGroupId,
+  parentGroupIndex,
+  createFieldRegistration,
+}: {
+  items: any[];
+  parentGroupId?: string;
+  parentGroupIndex?: number;
+  createFieldRegistration: (
+    fieldId: string,
+    parentGroupId?: string,
+    parentGroupIndex?: number
+  ) => void;
+}) {
+  items.forEach((item) => {
+    if (item.type === "container" && item.containerItems) {
+      registerAllFields({
+        items: item.containerItems,
+        parentGroupId,
+        parentGroupIndex,
+        createFieldRegistration,
+      });
+    } else if (item.type === "group" && item.groupItems) {
+      item.groupItems.forEach((groupItem: any, groupIndex: number) => {
+        registerAllFields({
+          items: groupItem.fields,
+          parentGroupId: item.id,
+          parentGroupIndex: groupIndex,
+          createFieldRegistration,
+        });
+      });
+    } else {
+      createFieldRegistration(item.id, parentGroupId, parentGroupIndex);
+    }
+  });
+}
+
+// Helper function to find field by ID
+export function findFieldById(
+  fieldId: string,
+  formDefinition: any
+): any | null {
+  const searchItems = (items: any[]): any | null => {
+    for (const item of items) {
+      if (item.id === fieldId) {
+        return item;
+      }
+      if (item.type === "container" && item.containerItems) {
+        const found = searchItems(item.containerItems);
+        if (found) return found;
+      }
+      if (item.type === "group" && item.groupItems) {
+        for (const groupItem of item.groupItems) {
+          const found = searchItems(groupItem.fields);
+          if (found) return found;
+        }
+      }
+    }
+    return null;
+  };
+
+  return searchItems(formDefinition.data.items);
+}
+
+// Helper function to identify if field is in a group based on ID structure
+export function parseFieldId(
+  fieldId: string,
+  groupStates: { [key: string]: any[] }
+): {
+  isGroupField: boolean;
+  groupId: string | null;
+  groupIndex: number | null;
+  originalFieldId: string;
+} {
+  for (const [groupId, groupStateArray] of Object.entries(groupStates)) {
+    for (
+      let groupIndex = 0;
+      groupIndex < groupStateArray.length;
+      groupIndex++
+    ) {
+      if (
+        groupStateArray[groupIndex] &&
+        fieldId in groupStateArray[groupIndex]
+      ) {
+        return {
+          isGroupField: true,
+          groupId,
+          groupIndex,
+          originalFieldId: fieldId,
+        };
+      }
+    }
+  }
+  return {
+    isGroupField: false,
+    groupId: null,
+    groupIndex: null,
+    originalFieldId: fieldId,
+  };
+}


### PR DESCRIPTION
## What changes did you make?
- support external state management for form fields, enabling custom scripts to access and manage state.
- Introduced a new `ExternalStateContext` in `src/ExternalStateContext.tsx` to provide a global store for managing form field states and interactions with external scripts. This includes methods for state management, field registration, and script initialization.
- Updated `Renderer.tsx` to register all form fields with the external state store and synchronize field states with the store. Added utility functions for field registration and state synchronization.
 - Modified `handleInputChange` to update the external state store whenever a field value changes.

**Code Enhancements**:
- Added support for a `class` attribute in the `Item` interface to facilitate field targeting by external scripts. This is specifically used by groups in order to allow children of repeaters to be targeted by classname (uuid identified in klamm)

## Why did you make these changes?

These changes were necessary in order to incorporate the management of react state without requiring extensive translation/interpretation. This also provides interoperability with DOM listeners and is primarily intended to allow for the updating and managing of calculated values.

## What alternatives did you consider?

Translation layers/shorthand. All would require too much specific work on direct translations/interpretations. This implementation leaves the work up to the developer to specifically identify/target items and determine what they want to do with them, while providing shorthand for integration with the react state. See the readme for examples of implementation.